### PR TITLE
Try to adquire the metadata in parallel

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -95,6 +95,10 @@ inputs:
   DOCKER_ENDPOINT:
     description: "Optional docker endpoint, e.g. quay.io"
     required: false
+  maxMetadataDownloads:
+    default: 5
+    description: "Max metadata downloads in parallel"
+    required: false
 runs:
   using: docker
   image: Dockerfile

--- a/main.go
+++ b/main.go
@@ -391,9 +391,11 @@ func downloadMeta() {
 			}
 
 			var wg sync.WaitGroup
+			semaphore := make(chan struct{}, 5)
 			metaErrors := make(chan error, len(metadata))
 			for _, m := range metadata {
 				meta := m
+				semaphore <- struct{}{}
 				wg.Add(1)
 				go func(m string) {
 					defer wg.Done()
@@ -402,6 +404,7 @@ func downloadMeta() {
 					err := downloadImage(img, *outputdir)
 					fmt.Println("Downloading finished", img)
 					metaErrors <- err
+					<-semaphore
 				}(meta)
 			}
 

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -54,6 +55,8 @@ var platform = flag.String("platform", "", "buildx platform")
 var luetVersion = flag.String("luetVersion", "0.20.10", "default Luet version")
 var arch = flag.String("luetArch", "amd64", "default Luet arch")
 var values = flag.String("values", "", "Values file")
+
+var maxMetadataDownloads = flag.String("maxMetadataDownloads", "5", "How many metadata to download in parallel")
 
 var outputdir = flag.String("output", "${PWD}/build", "output where to store packages")
 
@@ -391,7 +394,11 @@ func downloadMeta() {
 			}
 
 			var wg sync.WaitGroup
-			semaphore := make(chan struct{}, 10)
+			value, err := strconv.Atoi(*maxMetadataDownloads)
+			if err != nil {
+				value = 5
+			}
+			semaphore := make(chan struct{}, value)
 			metaErrors := make(chan error, len(metadata))
 			for _, m := range metadata {
 				meta := m

--- a/main.go
+++ b/main.go
@@ -391,7 +391,7 @@ func downloadMeta() {
 			}
 
 			var wg sync.WaitGroup
-			semaphore := make(chan struct{}, 5)
+			semaphore := make(chan struct{}, 10)
 			metaErrors := make(chan error, len(metadata))
 			for _, m := range metadata {
 				meta := m


### PR DESCRIPTION
Seems to be a bit faster:

PR build with forced all meta: https://github.com/kairos-io/packages/actions/runs/6545831432/job/17775097566?pr=494 => 42 seconds to download ALL meta
Main run which downloads all meta by default: https://github.com/kairos-io/packages/actions/runs/6544581310/job/17771324862 => 12 minutes

